### PR TITLE
Change fallback to same format as supported locales

### DIFF
--- a/express-gettext.js
+++ b/express-gettext.js
@@ -21,8 +21,8 @@ module.exports = function(app, options) {
     // Locales
     var localeDetector;
     var supportedLocales    = [];
-    var defaultLocale       = options.defaultLocale || 'en-US';
-    var currentLocale       = options.currentLocale || 'en-US';
+    var defaultLocale       = options.defaultLocale || 'en_US';
+    var currentLocale       = options.currentLocale || 'en_US';
 
     // Load translations from PO files
     var dirPath = path.join(options.directory, "**/*.po");


### PR DESCRIPTION
Changed dash to underscore to match the replace that happens when reading the supported locales from the folder paths.

Also renamed local variables named `locale` so not to give new meaning to global variable.
