### PR TITLE
Globals fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,21 +3,22 @@ express-gettext
 
 Translation middleware for express.js using Gettext and PO files. 
 
-I couldn't find any existing middleware that used PO files as the translation source (without converting them to JSON first), so there is a simple middleware that loads PO files, and exposes a simple gettext translate method on the ``request`` and ``app`` object to allow translations to be looked up from the server and in views.
+I couldn't find any existing middleware that used PO files as the translation source (without converting them to JSON first), so there is a simple middleware that loads PO files, and exposes a simple gettext translate method on the ``response`` and ``app`` object to allow translations to be looked up from the server and in views.
 
 ### Properties
-The middleware exposes two properties on the ``app`` object:
+The middleware exposes some methods on the ``app`` object. They use on the application's "default" locale:
 ```
-app.setCurrentLocale -> Method to set the current locale 
-app.currentLocale -> Getter to get the current locale
-req[alias] -> translate method
+app.setLocale -> Method to set the default locale
+app.getLocale || app.locals.getLocale || app.getDefaultLocale -> Methods to get the default locale
+app[alias] || app.locals[alias] -> translate method (using the default locale)
 ```
 
-Properties on the ```req`` object:
+Properties on the ```res`` object:
 ```
-req.setCurrentLocale -> Method to set the current locale 
-req.currentLocale -> Getter to get the current locale
-req[alias] -> translate method
+res.setLocale -> Method to set the current locale 
+res.getLocale || res.locals.getLocale -> Method to get the current locale
+res.getDefaultLocale -> Method to get the default (application) locale
+res[alias] || res.locals[alias] -> translate method
 ```
 ### Options
 ```

--- a/example/server.js
+++ b/example/server.js
@@ -19,7 +19,7 @@ app.use(express.static(__dirname + '/public'));
 app.get('/', function(req, res) {
 
     if(req.query && req.query.locale) {
-        req.setCurrentLocale(req.query.locale);
+        res.setLocale(req.query.locale);
     }
 
     res.render('index');

--- a/express-gettext.js
+++ b/express-gettext.js
@@ -20,9 +20,7 @@ module.exports = function(app, options) {
 
     // Locales
     var localeDetector;
-    var supportedLocales    = [];
-    var defaultLocale       = options.defaultLocale || 'en-US';
-    var currentLocale       = options.currentLocale || 'en-US';
+    var supportedLocales = [];
 
     // Load translations from PO files
     var dirPath = path.join(options.directory, "**/*.po");
@@ -37,16 +35,19 @@ module.exports = function(app, options) {
 
         files.forEach(function(file) {
 
-            var fileContents = fs.readFileSync(file);
-            var locale = file.match(/[a-z]{2}(-|_)[A-Z]{2}/)[0].replace('-','_').toLowerCase(); // Extract locale from path
+            var fileContents;
+            var match = file.match(/[a-z]{2}(-|_)[A-Z]{2}/); // Extract locale from path
+            var localeKey = match ? getLocaleKey(match[0]) : null;
 
-            if(locale) {
+            if(localeKey) {
 
-                if(locales.indexOf(locale) == -1) {
-                    locales.push(locale);
+                fileContents = fs.readFileSync(file);
+
+                if(locales.indexOf(localeKey) == -1) {
+                    locales.push(localeKey);
                 }
 
-                gt.addTextdomain(locale, fileContents);
+                gt.addTextdomain(localeKey, fileContents);
             }
 
         });
@@ -56,73 +57,134 @@ module.exports = function(app, options) {
 
     });
 
-    var getText = function(textKey, locale) {
-
-        var targetLocale = (locale || currentLocale).toLowerCase();
-        var text = gt._getTranslation(targetLocale, textKey);
-
-        if(!text) {
-            // Fallback to default langauge
-            var locale = defaultLocale.toLowerCase();
-            text = gt._getTranslation(locale, textKey);
-        }
-
-        if(!text) {
-            // Fallback to text key
-            text = '[MISSING]' + textKey;
-        }
-
-        return text;
-
-    }
-
-    var setCurrentLocale = function(locale) {
-        currentLocale = locale;
-    };
-
-    var getCurrentLocale = function() {
-        return currentLocale;
-    };
-
-    var getFormattedLocale = function() {
-        return getCurrentLocale().replace('_', '-');
-    }
-
-    var getSupportedLocales = function() {
-        return supportedLocales.toJSON().map(function(locale) {
+    function getSupportedLocales() {
+        return Array.prototype.map.call(supportedLocales, function(locale) {
             return locale.normalized;
         });
-    }
+    };
+
+    // Setup app
+    app.setLocale = setLocale;
+    app.getLocale = getLocale;
+    app.getDefaultLocale = getDefaultLocale;
+
+    app.getSupportedLocales = getSupportedLocales;
+
+    app[options.alias] = getText;
+
+    app.set('gettext instance', gt);
+    app.setLocale(options.defaultLocale || 'en-US');
 
     // Setup locals for Express
-    app.locals[options.alias] = getText;
-    app.locals.getCurrentLocale = getFormattedLocale;
-    app.locals.setCurrentLocale = setCurrentLocale;
+    app.locals[options.alias] = getText.bind(app);
+    app.locals.getLocale = getLocale.bind(app);
     app.locals.getSupportedLocales = getSupportedLocales;
 
-    // Return middleware function to map locals on Request
+    // For backwards compatibility
+    app.locals.setCurrentLocale = setLocale.bind(app);
+    app.locals.getCurrentLocale = app.locals.getLocale;
+
+    // Return middleware function to map locals on Response
     return function(req, res, next) {
+
+        // Set response helpers
+        res.setLocale = setLocale;
+        res.getLocale = getLocale;
+        res.getDefaultLocale = getDefaultLocale;
+        res.getSupportedLocales = getSupportedLocales;
+        res[options.alias] = getText;
+
+        // Set locals helpers
+        res.locals[options.alias] = getText.bind(res);
+        res.locals.getLocale = getLocale.bind(res);
+
+        // For backwards compatibility
+        res.locals.getCurrentLocale = res.locals.getLocale;
+
+        // Just to make sure it's accessible (some view engines don't inherit app's locals)
+        res.locals.getSupportedLocales = getSupportedLocales;
+
+        // backward compatibility helpers (not sure why we need locale on request object)
+        req.setCurrentLocale = setLocale.bind(res);
+        req.getCurrentLocale = getLocale.bind(res);
+        req.getSupportedLocales = getSupportedLocales;
 
         if(options.detectors.header) {
             var locales = new locale.Locales(req.headers[options.detectors.header])
             var matchedLocale = locales.best(supportedLocales);
 
-            setCurrentLocale(matchedLocale.normalized);
+            res.setLocale(matchedLocale.normalized);
         }
 
         if(options.detectors.query && req.query[options.detectors.query]) {
             var locales = new locale.Locales(req.query[options.detectors.query])
             var matchedLocale = locales.best(supportedLocales);
 
-            setCurrentLocale(matchedLocale.normalized);
+            res.setLocale(matchedLocale.normalized);
         }
-
-        res.locals[options.alias] = getText;
-        req.setCurrentLocale = setCurrentLocale;
-        req.getCurrentLocale = getFormattedLocale;
-        req.getSupportedLocales = getSupportedLocales;
 
         next();
     };
 
 }
+
+// Make locale RFC 5646 compliant
+function normalizeLocale(locale) {
+    // Dummy replace (doesn't ensure casing of country code)
+    // Consider using locale's normalization logic
+    return locale.replace('_', '-');
+}
+
+// Get key for given locale
+function getLocaleKey(locale) {
+    return locale.replace('-','_').toLowerCase();
+}
+
+function setLocale(locale) {
+    if (!this.locals) this.locals = Object.create(null);
+    this.locals.locale = normalizeLocale(locale);
+}
+
+function getLocale() {
+    var locale = this.locals ? this.locals.locale : null;
+    if (!locale && this.app) {
+        locale = getDefaultLocale.call(this.app);
+    }
+    return locale;
+}
+
+function getDefaultLocale() {
+    var app = getExpressApp(this);
+
+    return app.locals ? app.locals.locale : null;
+}
+
+function getExpressApp(reqOrApp) {
+    return isExpressApp(reqOrApp) ? reqOrApp : isExpressApp(reqOrApp.app) ? reqOrApp.app : null;
+}
+
+function isExpressApp(app) {
+    return app && typeof app.handle == 'function';
+}
+
+function getText(textKey, locale) {
+
+    var app = getExpressApp(this);
+    var gt = app.set('gettext instance');
+
+    var targetLocaleKey = getLocaleKey(locale || this.getLocale());
+    var text = gt._getTranslation(targetLocaleKey, textKey);
+
+    if(!text) {
+        // Fallback to default langauge
+        targetLocaleKey = getLocaleKey(this.getDefaultLocale());
+        text = gt._getTranslation(targetLocaleKey, textKey);
+    }
+
+    if(!text) {
+        // Fallback to text key
+        text = '[MISSING]' + textKey;
+    }
+
+    return text;
+};

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "express-gettext",
   "description": "An i18n middleware for the Express.js framework.",
-  "version": "0.1.6",
+  "version": "0.2.0",
   "repository": {
     "type": "git",
     "url": "git://github.com/auchenberg/express-gettext.git"


### PR DESCRIPTION
Store response and application (default) locale in the "locale" property of the respective locals objects.
Attach gettext instance on application's settings to avoid some unnecessary closures
Switch methods from request object to response object and make method names uniform
Store locale in normalized form and always lookup translation using uniform locale key transformation
Improved checks for null

Bump version to 0.2 because of API changes (old methods kept around for backward compatibility)
