### PR TITLE
Bump node-gettext version

### DIFF
--- a/express-gettext.js
+++ b/express-gettext.js
@@ -167,12 +167,12 @@ function getText(textKey, locale) {
     var fallback = app.set('gettext fallback');
 
     var targetLocaleKey = getLocaleKey(locale || this.getLocale());
-    var text = gt._getTranslation(targetLocaleKey, textKey);
+    var text = gt.dgettext(targetLocaleKey, textKey);
 
     if(!text) {
         // Fallback to default langauge
         targetLocaleKey = getLocaleKey(this.getDefaultLocale());
-        text = gt._getTranslation(targetLocaleKey, textKey);
+        text = gt.dgettext(targetLocaleKey, textKey);
     }
 
     if(!text) {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "express-gettext",
   "description": "An i18n middleware for the Express.js framework.",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "repository": {
     "type": "git",
     "url": "git://github.com/auchenberg/express-gettext.git"

--- a/package.json
+++ b/package.json
@@ -18,6 +18,6 @@
   "dependencies": {
     "glob": "~4.0.5",
     "locale": "0.0.17",
-    "node-gettext": "~0.2.14"
+    "node-gettext": "~1.0.1"
   }
 }


### PR DESCRIPTION
Updates to the latest node-gettext version and fixes changes in API:
- `_getTranslation()` now returns an object and has different ordering of params so is replaced with `dgettext()`
